### PR TITLE
Cluster: Adding parameter KeepDownedNodesInCluster to control whether or not to remove nodes in downed state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 ### Changed
 - Cluster
   - New parameter KeepDownedNodesInCluster controls whether or not to evict nodes in a down state from the cluster.
-
 - FailoverClusterDsc
   - Update pipeline files to the latest from the Sampler project.
   - Move somme documentation from README-md to the GitHub repository Wiki.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Changed
+- Cluster
+  - New parameter KeepDownedNodesInCluster controls whether or not to evict nodes in a down state from the cluster.
+
 - FailoverClusterDsc
   - Update pipeline files to the latest from the Sampler project.
   - Move somme documentation from README-md to the GitHub repository Wiki.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The resource examples are also available in the [FailoverClusterDsc Wiki](https:
     Full Control over the Cluster Name Object in Active Directory.
     * Otherwise the Computer Account must have been granted Full Control 
     over the Cluster Name Object in Active Directory.
+* **`[Boolean]` KeepDownedNodesInCluster** _(Write)_: Switch controlling whether or not
+  to evict cluster nodes in a down state from the cluster. Default value is 'false'.
 
 
 #### Examples for Cluster

--- a/source/DSCResources/DSC_Cluster/DSC_Cluster.psm1
+++ b/source/DSCResources/DSC_Cluster/DSC_Cluster.psm1
@@ -45,7 +45,11 @@ function Get-TargetResource
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $DomainAdministratorCredential
+        $DomainAdministratorCredential,
+
+        [Parameter()]
+        [System.Boolean]
+        $KeepDownedNodesInCluster = $false
     )
 
     Write-Verbose -Message ($script:localizedData.GetClusterInformation -f $Name)
@@ -142,7 +146,11 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $DomainAdministratorCredential
+        $DomainAdministratorCredential,
+
+        [Parameter()]
+        [System.Boolean]
+        $KeepDownedNodesInCluster = $false
     )
 
     $bCreate = $true
@@ -231,12 +239,20 @@ function Set-TargetResource
                 {
                     if ($node.State -eq 'Down')
                     {
-                        Write-Verbose -Message ($script:localizedData.RemoveOfflineNodeFromCluster -f $targetNodeName, $Name)
+                        if ($KeepDownedNodesInCluster)
+                        {
+                            Write-Verbose -Message ($script:localizedData.KeepDownedNodesInCluster -f $targetNodeName, $Name)
+                        }
+                        else
+                        {
+                            Write-Verbose -Message ($script:localizedData.RemoveOfflineNodeFromCluster -f $targetNodeName, $Name)
 
-                        Remove-ClusterNode -Name $targetNodeName -Cluster $Name -Force
+                            Remove-ClusterNode -Name $targetNodeName -Cluster $Name -Force
+                        }
                     }
                 }
             }
+
 
             Add-ClusterNode -Name $targetNodeName -Cluster $Name -NoStorage
 
@@ -312,7 +328,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Management.Automation.PSCredential]
-        $DomainAdministratorCredential
+        $DomainAdministratorCredential,
+
+        [Parameter()]
+        [System.Boolean]
+        $KeepDownedNodesInCluster = $false
     )
 
     $returnValue = $false

--- a/source/DSCResources/DSC_Cluster/DSC_Cluster.psm1
+++ b/source/DSCResources/DSC_Cluster/DSC_Cluster.psm1
@@ -25,6 +25,10 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
     .PARAMETER DomainAdministratorCredential
         Credential used to create the failover cluster in Active Directory.
+
+    .PARAMETER KeepDownedNodesInCluster
+        Switch used to determine whether or not to evict cluster nodes in a
+        downed state. Defaults to $false
 #>
 function Get-TargetResource
 {
@@ -118,6 +122,10 @@ function Get-TargetResource
 
     .PARAMETER DomainAdministratorCredential
         Credential used to create the failover cluster in Active Directory.
+
+    .PARAMETER KeepDownedNodesInCluster
+        Switch used to determine whether or not to evict cluster nodes in a
+        downed state. Defaults to $false
 
     .NOTES
         If the cluster does not exist, it will be created in the domain and the
@@ -296,6 +304,10 @@ function Set-TargetResource
 
     .PARAMETER DomainAdministratorCredential
         Credential used to create the failover cluster in Active Directory.
+
+    .PARAMETER KeepDownedNodesInCluster
+        Switch used to determine whether or not to evict cluster nodes in a
+        downed state. Defaults to $false
 
     .NOTES
         The code will check the following in order:

--- a/source/DSCResources/DSC_Cluster/DSC_Cluster.schema.mof
+++ b/source/DSCResources/DSC_Cluster/DSC_Cluster.schema.mof
@@ -7,5 +7,5 @@ class DSC_Cluster : OMI_BaseResource
     [Write, Description("StaticIPAddress of the Cluster")] String StaticIPAddress;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
     [Write, Description("One or more networks to ignore when creating the cluster. Only networks using Static IP can be ignored, networks that are assigned an IP address through DHCP cannot be ignored, and are added for cluster communication. To remove networks assigned an IP address through DHCP use the resource ClusterNetwork to change the role of the network. This parameter is only used during the creation of the cluster and is not monitored after.")] String IgnoreNetwork[];
-    [Write, Description("Remove nodes in down state from cluster")] Boolean KeepDownedNodesInCluster;
+    [Write, Description("Remove nodes in down state from cluster.")] Boolean KeepDownedNodesInCluster;
 };

--- a/source/DSCResources/DSC_Cluster/DSC_Cluster.schema.mof
+++ b/source/DSCResources/DSC_Cluster/DSC_Cluster.schema.mof
@@ -7,4 +7,5 @@ class DSC_Cluster : OMI_BaseResource
     [Write, Description("StaticIPAddress of the Cluster")] String StaticIPAddress;
     [Write, EmbeddedInstance("MSFT_Credential"), Description("Credential to create the cluster")] String DomainAdministratorCredential;
     [Write, Description("One or more networks to ignore when creating the cluster. Only networks using Static IP can be ignored, networks that are assigned an IP address through DHCP cannot be ignored, and are added for cluster communication. To remove networks assigned an IP address through DHCP use the resource ClusterNetwork to change the role of the network. This parameter is only used during the creation of the cluster and is not monitored after.")] String IgnoreNetwork[];
+    [Write, Description("Remove nodes in down state from cluster")] Boolean KeepDownedNodesInCluster;
 };

--- a/source/DSCResources/DSC_Cluster/en-US/DSC_Cluster.strings.psd1
+++ b/source/DSCResources/DSC_Cluster/en-US/DSC_Cluster.strings.psd1
@@ -20,4 +20,5 @@ ConvertFrom-StringData @'
     UnableToImpersonateUser = Can't logon as user {0}.
     UnableToCloseToken = Can't close impersonation token {0}.
     GetClusterInformation = Retrieving information for cluster {0}.
+    KeepDownedNodesInCluster = Cluster node {0} is in a down state and will not be removed from the cluster {1}.
 '@

--- a/source/Examples/Resources/Cluster/7-Cluster_JoinAdditionalNodeToFailoverClusterConfigAndDontEvictDownedNodes.ps1
+++ b/source/Examples/Resources/Cluster/7-Cluster_JoinAdditionalNodeToFailoverClusterConfigAndDontEvictDownedNodes.ps1
@@ -38,7 +38,7 @@ First version.
         This example shows how to add an additional node to the failover cluster without evicting cluster nodes in a down state.
 #>
 
-Configuration Cluster_JoinAdditionalNodeToFailoverClusterConfig
+Configuration Cluster_JoinAdditionalNodeToFailoverClusterConfigAndDontEvictDownedNodes
 {
     param
     (

--- a/source/Examples/Resources/Cluster/7-Cluster_JoinAdditionalNodeToFailoverClusterConfigAndDontEvictDownedNodes.ps1
+++ b/source/Examples/Resources/Cluster/7-Cluster_JoinAdditionalNodeToFailoverClusterConfigAndDontEvictDownedNodes.ps1
@@ -1,0 +1,91 @@
+<#PSScriptInfo
+
+.VERSION 1.0.0
+
+.GUID 593e1540-3778-4260-9389-1deceb419c8c
+
+.AUTHOR DSC Community
+
+.COMPANYNAME DSC Community
+
+.COPYRIGHT DSC Community contributors. All rights reserved.
+
+.TAGS DSCConfiguration
+
+.LICENSEURI https://github.com/dsccommunity/FailoverClusterDsc/blob/main/LICENSE
+
+.PROJECTURI https://github.com/dsccommunity/FailoverClusterDsc
+
+.ICONURI https://dsccommunity.org/images/DSC_Logo_300p.png
+
+.EXTERNALMODULEDEPENDENCIES
+
+.REQUIREDSCRIPTS
+
+.EXTERNALSCRIPTDEPENDENCIES
+
+.RELEASENOTES
+First version.
+
+.PRIVATEDATA 2016-Datacenter,2016-Datacenter-Server-Core
+
+#>
+
+#Requires -Module FailoverClusterDsc
+
+<#
+    .DESCRIPTION
+        This example shows how to add an additional node to the failover cluster without evicting cluster nodes in a down state.
+#>
+
+Configuration Cluster_JoinAdditionalNodeToFailoverClusterConfig
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [PSCredential]
+        $ActiveDirectoryAdministratorCredential
+    )
+
+    Import-DscResource -ModuleName FailoverClusterDsc
+
+    Node localhost
+    {
+        WindowsFeature AddFailoverFeature
+        {
+            Ensure = 'Present'
+            Name   = 'Failover-clustering'
+        }
+
+        WindowsFeature AddRemoteServerAdministrationToolsClusteringPowerShellFeature
+        {
+            Ensure    = 'Present'
+            Name      = 'RSAT-Clustering-PowerShell'
+            DependsOn = '[WindowsFeature]AddFailoverFeature'
+        }
+
+        WindowsFeature AddRemoteServerAdministrationToolsClusteringCmdInterfaceFeature
+        {
+            Ensure    = 'Present'
+            Name      = 'RSAT-Clustering-CmdInterface'
+            DependsOn = '[WindowsFeature]AddRemoteServerAdministrationToolsClusteringPowerShellFeature'
+        }
+
+        WaitForCluster WaitForCluster
+        {
+            Name             = 'Cluster01'
+            RetryIntervalSec = 10
+            RetryCount       = 60
+            DependsOn        = '[WindowsFeature]AddRemoteServerAdministrationToolsClusteringCmdInterfaceFeature'
+        }
+
+        Cluster JoinSecondNodeToCluster
+        {
+            Name                          = 'Cluster01'
+            StaticIPAddress               = '192.168.100.20/24'
+            DomainAdministratorCredential = $ActiveDirectoryAdministratorCredential
+            KeepDownedNodesInCluster      = $True
+            DependsOn                     = '[WaitForCluster]WaitForCluster'
+        }
+    }
+}

--- a/tests/Unit/DSC_Cluster.Tests.ps1
+++ b/tests/Unit/DSC_Cluster.Tests.ps1
@@ -459,9 +459,10 @@ foreach ($moduleVersion in @('2012', '2016'))
                         }
 
                         It 'Should not call Remove-ClusterNode when KeepDownedNodesInCluster is True' {
-
                             Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
+
                             $mockDefaultParametersKeepDownedNodes = $mockDefaultParameters + @{'KeepDownedNodesInCluster' = $True}
+
                             { Set-TargetResource @mockDefaultParametersKeepDownedNodes } | Should -Not -Throw
 
                             Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It

--- a/tests/Unit/DSC_Cluster.Tests.ps1
+++ b/tests/Unit/DSC_Cluster.Tests.ps1
@@ -457,6 +457,19 @@ foreach ($moduleVersion in @('2012', '2016'))
                             Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 1 -Scope It
                             Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 1 -Scope It
                         }
+
+                        It 'Should not call Remove-ClusterNode when KeepDownedNodesInCluster is True' {
+
+                            Mock -CommandName Get-Cluster -MockWith $mockGetCluster -ParameterFilter $mockGetCluster_ParameterFilter
+                            $mockDefaultParametersKeepDownedNodes = $mockDefaultParameters + @{'KeepDownedNodesInCluster' = $True}
+                            { Set-TargetResource @mockDefaultParametersKeepDownedNodes } | Should -Not -Throw
+
+                            Assert-MockCalled -CommandName New-Cluster -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
+                            Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 1 -Scope It
+                        }
+
+                        }
                     }
                 }
 

--- a/tests/Unit/DSC_Cluster.Tests.ps1
+++ b/tests/Unit/DSC_Cluster.Tests.ps1
@@ -468,8 +468,6 @@ foreach ($moduleVersion in @('2012', '2016'))
                             Assert-MockCalled -CommandName Remove-ClusterNode -Exactly -Times 0 -Scope It
                             Assert-MockCalled -CommandName Add-ClusterNode -Exactly -Times 1 -Scope It
                         }
-
-                        }
                     }
                 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Parameter `KeepDownedNodesInCluster` will control removing nodes in a down state. Defaulting to `false` current behavior is kept and nodes in a downed state will be evicted. When set to `true`, nodes in a down state will not be evicted.

#### This Pull Request (PR) fixes the following issues

- Fixes #257 

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [x] Comment-based help added/updated.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/failoverclusterdsc/272)
<!-- Reviewable:end -->
